### PR TITLE
Customized Auth0 login to only show options for: google, linkedIn, and facebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@
 <p>Feel free to contact us via:</p>
 <p>contact.myusual@gmail.com</p>
 <br>
-<br>
 <h2><b>Technologies We used to build this app:</b></h2>
 
 <h4>- Express.js</h4>

--- a/js/script.js
+++ b/js/script.js
@@ -435,7 +435,12 @@ function deleteListItem(e) {
 }
 // *********** Auth0 lock and login check
 //1. Client ID, 2. Client Domain, 3. Oject of Attr
-var lock = new Auth0Lock('GoBNjyrd7W9Jg1HECE7nH82QUhjTsM2B', 'jeauxy.auth0.com', {
+
+var options = {
+  allowedConnections: ['google-oauth2', 'facebook', 'linkedin']
+};
+
+var lock = new Auth0Lock('GoBNjyrd7W9Jg1HECE7nH82QUhjTsM2B', 'jeauxy.auth0.com', options, {
     auth: {
       params: {
         scope: 'openid email'


### PR DESCRIPTION
Custom user creation was bugged upon sign in. Showed unidentified usernames and wouldn't load store lists when very first list is created. It allows you to add item without stores because stores don't show up.
